### PR TITLE
Suggest zig 0.11 required

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -149,7 +149,7 @@ cd mach-examples/
 zig build run-boids
 </pre></code>
             <small>Cross-platform graphics, a unified shader language & compute shaders.</small>
-            <br/><small>Requires <a href="https://ziglang.org">zig 0.10.x</a> | 
+            <br/><small>Requires <a href="https://ziglang.org">zig 0.11.x</a> | 
 <a href="https://github.com/hexops/mach/blob/main/doc/known-issues.md#known-issues">known issues</a>
 </small>
         </div>


### PR DESCRIPTION
When compiling with the suggested 0.10, I encountered the following errors:

```
$ zig build run-boids
/home/duane/tmp/mach-examples/libs/mach/build.zig:224:50: error: expected error union type, found '[]build.Pkg'
            .dependencies = try deps.toOwnedSlice(),
                                ~~~~~~~~~~~~~~~~~^~
referenced by:
    build: /home/duane/tmp/mach-examples/build.zig:73:33
    runBuild: /home/duane/zig/lib/build_runner.zig:231:32
    remaining reference traces hidden; use '-freference-trace' to see all reference traces

/home/duane/tmp/mach-examples/libs/mach/tools/wasmserve/wasmserve.zig:564:14: error: no field named 'test_runner' in struct 'build.LibExeObjStep'
    if (self.test_runner) |test_runner| {
             ^~~~~~~~~~~
/home/duane/zig/lib/std/build.zig:1454:27: note: struct declared here
pub const LibExeObjStep = struct {
                          ^~~~~~
```

Compiling with zig 0.11 seems to be the correct course of action.