### PR TITLE
adds note about Xcursor depenency when using cursormode = disabled

### DIFF
--- a/content/docs/core/nixos-usage.md
+++ b/content/docs/core/nixos-usage.md
@@ -60,6 +60,13 @@ env NIXPKGS_ALLOW_UNFREE=1 nix-shell -p steam-run
 
 (then `zig build run-textured-cube` as usual)
 
+## Known issues
+### Incorrect cursor behavior with cursormode set to disabled
+
+If your cursor is not hidden and behaves "jumpy" after setting cursormode to disabled, you will need to add the `pkgs.xorg.libXcursor` package as an additional buildinput. This is required for both Xorg and Wayland.
+
+If capturing the cursor is not required, libXcursor can be omitted.
+
 ## Debugging tips
 
 * Mach requires a functional Vulkan graphics driver by default, but you can also try OpenGL via `MACH_GPU_BACKEND=opengl`


### PR DESCRIPTION
As already discussed, add a short note for the jumpy cursor issue on nixos. I'm not too sure if this is worded in a way that search engines will pick it up, so it may have to be changed a bit. 