### PR TITLE
mach-glfw: Change the example to show a blank window

### DIFF
--- a/content/pkg/mach-glfw.md
+++ b/content/pkg/mach-glfw.md
@@ -106,6 +106,7 @@ pub fn main() !void {
 
     // Wait for the user to close the window.
     while (!window.shouldClose()) {
+        window.swapBuffers();
         glfw.pollEvents();
     }
 }


### PR DESCRIPTION
Previously, the example would not show a window on my system (`aarch64-linux-musl`), and keep the event loop running at 100% until terminated. This should be everything needed for a minimal example :)