### PR TITLE
Fix the Getting stared build.zig for 2024.1.0-mach

### DIFF
--- a/content/core/getting-started.md
+++ b/content/core/getting-started.md
@@ -79,7 +79,7 @@ pub fn build(b: *std.Build) !void {
         .src = "src/main.zig",
         .target = target,
         .optimize = optimize,
-        .deps = &[_]std.build.ModuleDependency{},
+        .deps = &[_]std.Build.Module.Import{},
     });
     if (b.args) |args| app.run.addArgs(args);
 


### PR DESCRIPTION
This fixes the `build.zig` for the newly released nominated Zig version 2024.1.0-mach.