### PR TITLE
fixed link to new version post on main page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ baseURL = 'https://machengine.org/'
   branch = 'main'
 
   # Other branch-agnostic site params below
-  alert = '**Mach v0.3 has been released!** For all the details check out [the announcement](https://devlog.hexops.com/2023/mach-v0.2-released/)'
+  alert = '**Mach v0.3 has been released!** For all the details check out [the announcement](https://devlog.hexops.com/2024/mach-v0.3-released/)'
   #alert = '**Mach now _nominates Zig versions for use!_** For details check out [the docs](/about/nominated-zig)'
   debug_opengraph_images = false
 


### PR DESCRIPTION
Ensured that the link on top of the main page which announces v0.3 points to the correct blog post