### PR TITLE
mach-glfw package name typo fixed

### DIFF
--- a/content/pkg/mach-glfw.md
+++ b/content/pkg/mach-glfw.md
@@ -65,7 +65,7 @@ Add the following to your `build.zig` below your `const exe = b.addExecutable(..
 
 ```zig
     // Use mach-glfw
-    const glfw_dep = b.dependency("mach_glfw", .{
+    const glfw_dep = b.dependency("mach-glfw", .{
         .target = target,
         .optimize = optimize,
     });


### PR DESCRIPTION
the name of package is mach-glfw but it was trying to use mach_glfw which gave a compile time error for me.