### PR TITLE
Don't add scrollbars to `<pre>` tags on Windows

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -547,7 +547,7 @@ pre {
     color: $light_bg;
     tab-size: 4;
     font-size: 16px;
-    overflow: scroll;
+    overflow: auto;
 }
 
 .code {


### PR DESCRIPTION
Hi! I noticed that on the Mach site on Windows, the `<pre>` tags used for code examples have scrollbars even though there is no overflow.

![image](https://github.com/user-attachments/assets/e369955e-2071-4e67-a6b7-2377e217eba9)

This PR makes a very minor change so that the scrollbars only show up when the code examples overflow. I tested with a local Hugo build and the fix seemed to work.

![image](https://github.com/user-attachments/assets/4de8f36c-857e-41f1-96d0-2c573be2a4e8)

It does seem like the code examples' lines wrap when they maybe shouldn't. But that's a different issue that seems a little harder to solve. 